### PR TITLE
Bump lodestar to v1.15.1

### DIFF
--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -8,10 +8,10 @@ RUN apt update && apt install -y git g++ make python3
 
 RUN git clone https://github.com/ChainSafe/lodestar
 
-ARG LODESTAR_VERSION
+ARG VALIDATOR_CLIENT_VERSION
 
 RUN cd ./lodestar && \
-    git checkout ${LODESTAR_VERSION} && \
+    git checkout ${VALIDATOR_CLIENT_VERSION} && \
     yarn install --non-interactive --frozen-lockfile && \
     yarn build && \
     yarn install --non-interactive --frozen-lockfile --production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 1
     restart: on-failure
     volumes:
@@ -40,7 +40,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 2
     restart: on-failure
     volumes:
@@ -74,7 +74,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 3
     restart: on-failure
     volumes:
@@ -108,7 +108,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 4
     restart: on-failure
     volumes:
@@ -142,7 +142,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 5
     restart: on-failure
     volumes:


### PR DESCRIPTION
Bump lodestar validator client version to `v1.15.1`

Also, `LODESTAR_VERSION` env variable was replaced by `VALIDATOR_CLIENT_VERSION`. Previous code resulted in latest upstream version being downloaded from official repo (instead of version defined in compose file