### PR TITLE
Add prometheus service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,19 @@ services:
     security_opt:
       - seccomp:unconfined
     image: charon-validator-5.holesky-obol.dnp.dappnode.eth:0.1.0
+  prometheus:
+    build:
+      context: prometheus
+      args:
+        PROMETHEUS_VERSION: v2.51.1
+    environment:
+      MONITORING_URL: https://vm.monitoring.gcp.obol.tech/write
+      MONITORING_CREDENTIALS: ""
+      ACTIVE_CHARONS_NUMBER: 1
+    volumes:
+      - "prometheus-data:/prometheus"
+    restart: unless-stopped
+    image: "prometheus.holesky-obol.dnp.dappnode.eth:0.1.0"
 volumes:
   charon-1-data: {}
   charon-2-data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,3 +194,4 @@ volumes:
   validator-3-data: {}
   validator-4-data: {}
   validator-5-data: {}
+  prometheus-data: {}

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -3,4 +3,13 @@ ARG PROMETHEUS_VERSION
 
 FROM prom/prometheus:${PROMETHEUS_VERSION}
 
-COPY prometheus.yml /etc/prometheus/prometheus.yml
+ENV TEMPLATE_CONFIG_FILE=/etc/prometheus/prometheus_template.yml \
+    CONFIG_FILE=/etc/prometheus/prometheus.yml
+
+COPY prometheus_template.yml /etc/prometheus/
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+USER root
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/prometheus/entrypoint.sh
+++ b/prometheus/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# These envs are defined in the compose file: MONITORING_URL, MONITORING_CREDENTIALS, ACTIVE_CHARONS_NUMBER
+
+if [ -z "$MONITORING_URL" ] || [ -z "$MONITORING_CREDENTIALS" ]; then
+    echo "MONITORING_URL and MONITORING_CREDENTIALS must be set in the config to enable monitoring"
+    exit 0 # To avoid restart
+fi
+
+# If active charons is not a number or is <=0, then exits
+if ! [ "$ACTIVE_CHARONS_NUMBER" -eq "$ACTIVE_CHARONS_NUMBER" ] 2>/dev/null || [ "$ACTIVE_CHARONS_NUMBER" -le 0 ]; then
+    echo "ACTIVE_CHARONS_NUMBER must be a number greater than 0"
+    exit 0 # To avoid restart
+fi
+
+# Generate charon and validator targets based on the number of active charons
+# Example: If ACTIVE_CHARONS_NUMBER=3, then <CHARON_TARGETS> will be replaced by ["charon-validator-1:3620", "charon-validator-2:3620", "charon-validator-3:3620"]
+charon_targets=""
+validator_targets=""
+for i in $(seq 1 $ACTIVE_CHARONS_NUMBER); do
+    if [ "$charon_targets" != "" ]; then
+        charon_targets="$charon_targets, "
+        validator_targets="$validator_targets, "
+    fi
+    charon_targets="${charon_targets}\"charon-validator-$i:3620\""
+    validator_targets="${validator_targets}\"charon-validator-$i:8008\""
+done
+
+# Wrap the generated strings in brackets (arrays)
+charon_targets="[$charon_targets]"
+validator_targets="[$validator_targets]"
+
+# Replace placeholders in the configuration template
+sed -e "s|<MONITORING_URL>|$MONITORING_URL|g" \
+    -e "s|<MONITORING_CREDENTIALS>|$MONITORING_CREDENTIALS|g" \
+    -e "s|<CHARON_TARGETS>|$charon_targets|g" \
+    -e "s|<VALIDATOR_TARGETS>|$validator_targets|g" \
+    $TEMPLATE_CONFIG_FILE >$CONFIG_FILE
+
+exec /bin/prometheus --config.file $CONFIG_FILE_PATH

--- a/prometheus/prometheus_template.yml
+++ b/prometheus/prometheus_template.yml
@@ -3,9 +3,9 @@ global:
   evaluation_interval: 30s # Evaluate rules every 30 seconds.
 
 remote_write:
-  - url: https://vm.monitoring.gcp.obol.tech/write
+  - url: <MONITORING_URL>
     authorization:
-      credentials: oboln!auNAZyJs!IYneXhQviJICT0H?mcxuZjO2g=WXqJTbjs-9r2P52q!vlDNpq?eLx7gbgmJgKDCmnxtoQMgZ5KmDeXTMttmlRsF/dNzxoePjkIbKWuGY25v2fc9RO
+      credentials: <MONITORING_CREDENTIALS>
     write_relabel_configs:
       - source_labels: [job]
         regex: "charon"
@@ -14,7 +14,7 @@ remote_write:
 scrape_configs:
   - job_name: "charon"
     static_configs:
-      - targets: ["charon-validator-1:3620"]
+      - targets: <CHARON_TARGETS> # ["charon-validator-1:3620"]
   - job_name: "validator"
     static_configs:
-      - targets: ["charon-validator-1:8008"]
+      - targets: <VALIDATOR_TARGETS> # ["charon-validator-1:8008"]


### PR DESCRIPTION
Add prometheus service to send metrics to the Obol monitoring server. View https://docs.obol.tech/docs/advanced/obol-monitoring

In order to send the metrics, there are 3 variables to specify:
`MONITORING_URL` Metrics server URL (by default `https://vm.monitoring.gcp.obol.tech/write`)
`MONITORING_CREDENTIALS`: Credentials to push metrics to the server
`ACTIVE_CHARONS_NUMBER`: Number of charons currently active for which the metrics should be retrieved and pushed to the server