### PR TITLE
Include spacing in ENR keys to show in pkg info

### DIFF
--- a/charon-validator/entrypoint.sh
+++ b/charon-validator/entrypoint.sh
@@ -165,7 +165,7 @@ function post_ENR_to_dappmanager() {
         --retry 5 \
         --retry-delay 0 \
         --retry-max-time 40 \
-        -X POST "http://my.dappnode/data-send?key=ENR-Cluster-${CLUSTER_ID}&data=${ENR}" ||
+        -X POST "http://my.dappnode/data-send?key=ENR%20Cluster%20${CLUSTER_ID}&data=${ENR}" ||
         {
             echo "[ERROR] failed to post ENR to dappmanager"
             exit 1


### PR DESCRIPTION
Use URL encoding to include spacing in the package info keys for the data sent. Now, instead of showing keys like `ENR-Cluster-1` the package info will show `ENR Cluster 1`