### PR TITLE
Avoid prometheus restart on credentials not set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
       ACTIVE_CHARONS_NUMBER: 1
     volumes:
       - "prometheus-data:/prometheus"
-    restart: unless-stopped
+    restart: on-failure
     image: "prometheus.holesky-obol.dnp.dappnode.eth:0.1.0"
 volumes:
   charon-1-data: {}


### PR DESCRIPTION
Docker restart policy `unless-stoped` results in a restart loop for prometheus service when the monitoring URL or credentials are not set:

```
MONITORING_URL and MONITORING_CREDENTIALS must be set in the config to enable monitoring
```