### PR TITLE
Restart container on artifact upload

### DIFF
--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -23,7 +23,7 @@ USER root
 
 # Install NodeJS to run Lodestar
 RUN apt-get update && \
-    apt-get install -y curl jq zip xz-utils && \
+    apt-get install -y curl jq zip xz-utils inotify-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 

--- a/charon-validator/Dockerfile.teku
+++ b/charon-validator/Dockerfile.teku
@@ -6,7 +6,7 @@ USER root
 
 # Install Java to run Teku
 RUN apt-get update && \
-    apt-get install -y jq curl openjdk-17-jdk zip xz-utils && \
+    apt-get install -y jq curl openjdk-17-jdk zip xz-utils inotify-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 

--- a/charon-validator/entrypoint.sh
+++ b/charon-validator/entrypoint.sh
@@ -107,7 +107,6 @@ function handle_charon_file_import() {
 
 function enable_restart_on_artifact_upload() {
     echo "${INFO} Enabling restart on artifact upload in ${IMPORT_DIR}"
-    local charon_pid=$(pidof charon)
 
     # Monitor the IMPORT_DIR for new files and restart the charon process if a new file is detected
     (inotifywait -m -q -e close_write --format '%f' "${IMPORT_DIR}" | while read -r filename; do
@@ -117,7 +116,7 @@ function enable_restart_on_artifact_upload() {
         if [[ "${filename}" =~ \.zip$|\.tar\.gz$|\.tar\.xz$ ]]; then
             echo "${INFO} Artifact ${filename} uploaded, triggering container restart..."
             # Forcefully terminate the charon process to trigger a container restart
-            kill -s SIGKILL $charon_pid
+            kill -s SIGKILL $(pidof charon)
         fi
     done) &
 }

--- a/charon-validator/entrypoint.sh
+++ b/charon-validator/entrypoint.sh
@@ -117,7 +117,7 @@ function enable_restart_on_artifact_upload() {
         if [[ "${filename}" =~ \.zip$|\.tar\.gz$|\.tar\.xz$ ]]; then
             echo "${INFO} Artifact ${filename} uploaded, triggering container restart..."
             # Forcefully terminate the charon process to trigger a container restart
-            kill -SIGKILL $charon_pid
+            kill -s SIGKILL $charon_pid
         fi
     done) &
 }


### PR DESCRIPTION
Container is now restarted on artifact upload by sending a SIGKILL to the main process (charon) so that it returns an error exit code that forces the container to be restarted due to the restart `on-failure` policy defined in the compose file