### PR TITLE
Define charons to monitor as an array

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -18,6 +18,18 @@ fields:
       service: cluster-1
     required: false
 
+    - id: prometheus_monitored_charons
+    title: Charons to monitor by Obol
+    description: |
+      Comma separated list of charon services to monitor by Obol team for performance and reliability. The prometheus service will send the metrics to the server defined by the monitoring URL.
+
+      Example: "1,2,3"
+    target:
+      type: environment
+      name: CHARONS_TO_MONITOR
+      service: prometheus
+    required: false
+
   - id: definition-file-url-1
     target:
       type: environment


### PR DESCRIPTION
Define what charons are going to be monitored by Obol monitoring server by setting a comma-separated string identifying the clusters to be monitored, like: "1,2,3"