### PR TITLE
bump ObolNetwork/charon to v0.19.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "name": "holesky-obol.dnp.dappnode.eth",
   "version": "0.1.0",
   "upstreamArg": ["UPSTREAM_VERSION", "VALIDATOR_CLIENT_VERSION"],
-  "upstreamVersion": ["v0.19.2", "v1.17.0"],
+  "upstreamVersion": "v0.19.2",
   "upstreamRepo": ["ObolNetwork/charon", "ChainSafe/lodestar"],
   "shortDescription": "Obol Node for Distributed validation + validator client",
   "description": "Charon is a GoLang-based, HTTP middleware built by Obol to enable any existing Ethereum validator clients to operate together as part of a distributed validator.\nCharon sits as a middleware between a normal validating client and its connected beacon node, intercepting and proxying API traffic. Multiple Charon clients are configured to communicate together to come to consensus on validator duties and behave as a single unified proof-of-stake validator together. The nodes form a cluster that is byzantine-fault tolerant and continues to progress assuming a supermajority of working/honest nodes is met.",


### PR DESCRIPTION
Bumps upstream version

- [ObolNetwork/charon](https://github.com/ObolNetwork/charon) from v0.19.0 to [v0.19.2](https://github.com/ObolNetwork/charon/releases/tag/v0.19.2)