### PR TITLE
Use new upstream definition format

### DIFF
--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -1,4 +1,4 @@
-ARG UPSTREAM_VERSION
+ARG CHARON_VERSION
 
 FROM node:20-bullseye-slim as lodestar-build
 
@@ -17,7 +17,7 @@ RUN cd ./lodestar && \
     yarn build && \
     yarn install --non-interactive --frozen-lockfile --production
 
-FROM obolnetwork/charon:${UPSTREAM_VERSION}
+FROM obolnetwork/charon:${CHARON_VERSION}
 
 USER root
 

--- a/charon-validator/Dockerfile.teku
+++ b/charon-validator/Dockerfile.teku
@@ -1,6 +1,6 @@
-ARG UPSTREAM_VERSION
+ARG CHARON_VERSION
 
-FROM obolnetwork/charon:${UPSTREAM_VERSION}
+FROM obolnetwork/charon:${CHARON_VERSION}
 
 USER root
 

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,9 +1,18 @@
 {
   "name": "holesky-obol.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamArg": ["UPSTREAM_VERSION", "VALIDATOR_CLIENT_VERSION"],
-  "upstreamVersion": ["v0.19.2", "v1.17.0"],
-  "upstreamRepo": ["ObolNetwork/charon", "ChainSafe/lodestar"],
+  "upstream": [
+    {
+      "repo": "ObolNetwork/charon",
+      "version": "v0.19.2",
+      "arg": "CHARON_VERSION"
+    },
+    {
+      "repo": "ChainSafe/lodestar",
+      "version": "v0.19.2",
+      "arg": "VALIDATOR_CLIENT_VERSION"
+    }
+  ],
   "shortDescription": "Obol Node for Distributed validation + validator client",
   "description": "Charon is a GoLang-based, HTTP middleware built by Obol to enable any existing Ethereum validator clients to operate together as part of a distributed validator.\nCharon sits as a middleware between a normal validating client and its connected beacon node, intercepting and proxying API traffic. Multiple Charon clients are configured to communicate together to come to consensus on validator duties and behave as a single unified proof-of-stake validator together. The nodes form a cluster that is byzantine-fault tolerant and continues to progress assuming a supermajority of working/honest nodes is met.",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        UPSTREAM_VERSION: v0.19.2
+        CHARON_VERSION: v0.19.2
         VALIDATOR_CLIENT_VERSION: v1.17.0
         CLUSTER_ID: 1
     restart: on-failure
@@ -40,7 +40,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        UPSTREAM_VERSION: v0.19.2
+        CHARON_VERSION: v0.19.2
         VALIDATOR_CLIENT_VERSION: v1.17.0
         CLUSTER_ID: 2
     restart: on-failure
@@ -74,7 +74,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        UPSTREAM_VERSION: v0.19.2
+        CHARON_VERSION: v0.19.2
         VALIDATOR_CLIENT_VERSION: v1.17.0
         CLUSTER_ID: 3
     restart: on-failure
@@ -109,7 +109,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        UPSTREAM_VERSION: v0.19.2
+        CHARON_VERSION: v0.19.2
         VALIDATOR_CLIENT_VERSION: v1.17.0
         CLUSTER_ID: 4
     restart: on-failure
@@ -144,7 +144,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        UPSTREAM_VERSION: v0.19.2
+        CHARON_VERSION: v0.19.2
         VALIDATOR_CLIENT_VERSION: v1.17.0
         CLUSTER_ID: 5
     restart: on-failure


### PR DESCRIPTION
In the manifest, use the new upstream definition format, specificated in https://github.com/dappnode/DAppNodeSDK/issues/408#issuecomment-2063702185