### PR TITLE
Bump lodestar 1.18.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -9,7 +9,7 @@
     },
     {
       "repo": "ChainSafe/lodestar",
-      "version": "v0.19.2",
+      "version": "v1.18.0",
       "arg": "VALIDATOR_CLIENT_VERSION"
     }
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.17.0
+        VALIDATOR_CLIENT_VERSION: v1.18.0
         CLUSTER_ID: 1
     restart: on-failure
     volumes:
@@ -41,7 +41,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.17.0
+        VALIDATOR_CLIENT_VERSION: v1.18.0
         CLUSTER_ID: 2
     restart: on-failure
     volumes:
@@ -75,7 +75,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.17.0
+        VALIDATOR_CLIENT_VERSION: v1.18.0
         CLUSTER_ID: 3
     restart: on-failure
     volumes:
@@ -110,7 +110,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.17.0
+        VALIDATOR_CLIENT_VERSION: v1.18.0
         CLUSTER_ID: 4
     restart: on-failure
     volumes:
@@ -145,7 +145,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.17.0
+        VALIDATOR_CLIENT_VERSION: v1.18.0
         CLUSTER_ID: 5
     restart: on-failure
     volumes:


### PR DESCRIPTION
Bump lodestar to `v1.18.0`

Also, fixed lodestar version, which was wrongly set in manifest