### PR TITLE
Bump charon to v1.0.0-rc2

### DIFF
--- a/charon-validator/entrypoint.sh
+++ b/charon-validator/entrypoint.sh
@@ -284,7 +284,6 @@ function run_lodestar() {
             --graffiti="${GRAFFITI}" \
             --suggestedFeeRecipient="${DEFAULT_FEE_RECIPIENT}" \
             --distributed \
-            --useProduceBlockV3=false \
             ${VALIDATOR_EXTRA_OPTS}
     ) &
     VALIDATOR_CLIENT_PID=$!
@@ -306,7 +305,7 @@ function run_teku() {
             --network=${NETWORK} \
             --validators-proposer-default-fee-recipient=${DEFAULT_FEE_RECIPIENT} \
             --validators-graffiti=${GRAFFITI} \
-            --Xblock-v3-enabled=false \
+            --Xblock-v3-enabled=true \
             ${VALIDATOR_EXTRA_OPTS}
     ) &
     VALIDATOR_CLIENT_PID=$!

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,7 +4,7 @@
   "upstream": [
     {
       "repo": "ObolNetwork/charon",
-      "version": "v0.19.2",
+      "version": "v1.0.0-rc2",
       "arg": "CHARON_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc2
         VALIDATOR_CLIENT_VERSION: v1.18.1
         CLUSTER_ID: 1
     restart: on-failure
@@ -40,7 +40,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc2
         VALIDATOR_CLIENT_VERSION: v1.18.1
         CLUSTER_ID: 2
     restart: on-failure
@@ -75,7 +75,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc2
         VALIDATOR_CLIENT_VERSION: v1.18.1
         CLUSTER_ID: 3
     restart: on-failure
@@ -110,7 +110,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc2
         VALIDATOR_CLIENT_VERSION: v1.18.1
         CLUSTER_ID: 4
     restart: on-failure
@@ -145,7 +145,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc2
         VALIDATOR_CLIENT_VERSION: v1.18.1
         CLUSTER_ID: 5
     restart: on-failure


### PR DESCRIPTION
Bump charon to v1.0.0-rc2, requested by the Obol team