### PR TITLE
Bump charon@v1.0.0-rc3 and lodestar@v1.19.0

### DIFF
--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -1,48 +1,27 @@
 ARG CHARON_VERSION
-
-FROM node:20-bullseye-slim as lodestar-build
-
-WORKDIR /usr/app
-
-RUN apt update && apt install -y git g++ make python3 && \
-    ln -s /usr/bin/python3 /usr/bin/python
-
-RUN git clone https://github.com/ChainSafe/lodestar
-
-ARG VALIDATOR_CLIENT_VERSION
-
-RUN cd ./lodestar && \
-    git checkout ${VALIDATOR_CLIENT_VERSION} && \
-    yarn install --non-interactive --frozen-lockfile && \
-    yarn build && \
-    yarn install --non-interactive --frozen-lockfile --production
-
 FROM obolnetwork/charon:${CHARON_VERSION}
+
+ARG CLUSTER_ID
+ARG VALIDATOR_CLIENT_VERSION
 
 USER root
 
-# Install NodeJS to run Lodestar
-RUN apt-get update && \
-    apt-get install -y curl jq zip xz-utils inotify-tools && \
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs jq zip xz-utils inotify-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-RUN curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh && \
-    chmod 500 nsolid_setup_deb.sh && \
-    ./nsolid_setup_deb.sh 20 && \
-    apt-get install -y nodejs && \
-    rm nsolid_setup_deb.sh
-
-COPY --from=lodestar-build /usr/app/lodestar /opt/validator
+RUN mkdir -p /opt/validator/bin && \
+    curl -L https://github.com/ChainSafe/lodestar/releases/download/${VALIDATOR_CLIENT_VERSION}/lodestar-${VALIDATOR_CLIENT_VERSION}-linux-amd64.tar.gz | tar -xz -C /opt/validator/bin
 
 COPY entrypoint.sh /entrypoint.sh
 
 # To prevent the user from editing the CLUSTER_ID, we set it as an ARG
-ARG CLUSTER_ID
 ENV CLUSTER_ID=${CLUSTER_ID} \
     CHARON_LOG_FORMAT=console \
     NETWORK=holesky \ 
-    VALIDATOR_SERVICE_BIN=/opt/validator/packages/cli/bin/lodestar \
+    VALIDATOR_SERVICE_BIN=/opt/validator/bin/lodestar \
     VALIDATOR_DATA_DIR=/opt/validator/data \
     VALIDATOR_METRICS_PORT=8008 \
     CHARON_VALIDATOR_API_ADDRESS="0.0.0.0:3600" \
@@ -51,6 +30,8 @@ ENV CLUSTER_ID=${CLUSTER_ID} \
     VALIDATOR_CLIENT="lodestar"
 
 RUN mkdir -p /opt/charon/.charon ${VALIDATOR_DATA_DIR} ${IMPORT_DIR} && chown -R charon:charon /opt/charon
+
+USER charon
 
 # To import here the artifacts from file manager by default
 WORKDIR /import

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,12 +4,12 @@
   "upstream": [
     {
       "repo": "ObolNetwork/charon",
-      "version": "v1.0.0-rc2",
+      "version": "v1.0.0-rc3",
       "arg": "CHARON_VERSION"
     },
     {
       "repo": "ChainSafe/lodestar",
-      "version": "v1.18.1",
+      "version": "v1.19.0",
       "arg": "VALIDATOR_CLIENT_VERSION"
     }
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v1.0.0-rc2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        CHARON_VERSION: v1.0.0-rc3
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 1
     restart: on-failure
     volumes:
@@ -40,8 +40,8 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v1.0.0-rc2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        CHARON_VERSION: v1.0.0-rc3
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 2
     restart: on-failure
     volumes:
@@ -75,8 +75,8 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v1.0.0-rc2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        CHARON_VERSION: v1.0.0-rc3
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 3
     restart: on-failure
     volumes:
@@ -110,8 +110,8 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v1.0.0-rc2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        CHARON_VERSION: v1.0.0-rc3
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 4
     restart: on-failure
     volumes:
@@ -145,8 +145,8 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v1.0.0-rc2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        CHARON_VERSION: v1.0.0-rc3
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 5
     restart: on-failure
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
       - seccomp:unconfined
-    image: cluster-1.holesky-obol.dnp.dappnode.eth:0.1.0
+    image: cluster-1.holesky-obol.dnp.dappnode.eth:0.1.1
   cluster-2:
     build:
       context: charon-validator
@@ -69,7 +69,7 @@ services:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
       - seccomp:unconfined
-    image: cluster-2.holesky-obol.dnp.dappnode.eth:0.1.0
+    image: cluster-2.holesky-obol.dnp.dappnode.eth:0.1.1
   cluster-3:
     build:
       context: charon-validator
@@ -104,7 +104,7 @@ services:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
       - seccomp:unconfined
-    image: cluster-3.holesky-obol.dnp.dappnode.eth:0.1.0
+    image: cluster-3.holesky-obol.dnp.dappnode.eth:0.1.1
   cluster-4:
     build:
       context: charon-validator
@@ -139,7 +139,7 @@ services:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
       - seccomp:unconfined
-    image: cluster-4.holesky-obol.dnp.dappnode.eth:0.1.0
+    image: cluster-4.holesky-obol.dnp.dappnode.eth:0.1.1
   cluster-5:
     build:
       context: charon-validator
@@ -174,7 +174,7 @@ services:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
       - seccomp:unconfined
-    image: cluster-5.holesky-obol.dnp.dappnode.eth:0.1.0
+    image: cluster-5.holesky-obol.dnp.dappnode.eth:0.1.1
   prometheus:
     build:
       context: prometheus
@@ -187,7 +187,7 @@ services:
     volumes:
       - prometheus-data:/prometheus
     restart: on-failure
-    image: prometheus.holesky-obol.dnp.dappnode.eth:0.1.0
+    image: prometheus.holesky-obol.dnp.dappnode.eth:0.1.1
 volumes:
   charon-1-data: {}
   charon-2-data: {}


### PR DESCRIPTION
Key changes:

1. New lodestar version includes the binary as an asset, so it is directly downloaded, instead of being built from source
2. Bump charon to `v1.0.0-rc3` (for Lido test) and lodestar to `v1.19.0`
3. Node installation now uses the recommended flow described in https://deb.nodesource.com/
4. Removed flag `--useProduceBlockV3=false` from lodestar and set `--Xblock-v3-enabled` to `true` in teku