### PR TITLE
Set root user

### DIFF
--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -31,8 +31,6 @@ ENV CLUSTER_ID=${CLUSTER_ID} \
 
 RUN mkdir -p /opt/charon/.charon ${VALIDATOR_DATA_DIR} ${IMPORT_DIR} && chown -R charon:charon /opt/charon
 
-USER charon
-
 # To import here the artifacts from file manager by default
 WORKDIR /import
 


### PR DESCRIPTION
Set root user in lodestar Dockerfile to avoid:
`09:53:20.821 ERRO cmd        Fatal error: load priv key: read private key from disk: open /opt/charon/.charon/charon-enr-private-key: permission denied {"file": "/opt/charon/.charon/charon-enr-private-key"}`