### PR TITLE
Fix file uncompression

### DIFF
--- a/charon-validator/entrypoint.sh
+++ b/charon-validator/entrypoint.sh
@@ -60,12 +60,10 @@ function extract_file_into_charon_dir() {
     tmp_dir=$(mktemp -d)
 
     # Extract the archive to the temporary directory
-    if [[ "${1}" == *.tar.gz ]]; then
-        tar -xzf "${1}" -C "${tmp_dir}" && echo "${INFO} Extraction to temp directory complete."
-    elif [[ "${1}" == *.tar.xz ]]; then
-        tar -xJf "${1}" -C "${tmp_dir}" && echo "${INFO} Extraction to temp directory complete."
+    if [[ "${1}" == *.tar.gz || "${1}" == *.tar.xz ]]; then
+        tar -xvf "${1}" -C "${tmp_dir}" && echo "${INFO} Extraction (.tar.gz or .tar.xz format) to temporary directory complete."
     elif [[ "${1}" == *.zip ]]; then
-        unzip -o "${1}" -d "${tmp_dir}" && echo "${INFO} Extraction to temp directory complete."
+        unzip -o "${1}" -d "${tmp_dir}" && echo "${INFO} Extraction (.zip format) to temporary directory complete."
     fi
 
     # Read contents of the temp directory into an array using mapfile

--- a/charon-validator/entrypoint.sh
+++ b/charon-validator/entrypoint.sh
@@ -61,7 +61,7 @@ function extract_file_into_charon_dir() {
 
     # Extract the archive to the temporary directory
     if [[ "${1}" == *.tar.gz || "${1}" == *.tar.xz ]]; then
-        tar -xvf "${1}" -C "${tmp_dir}" && echo "${INFO} Extraction (.tar.gz or .tar.xz format) to temporary directory complete."
+        tar --exclude='._*' -xvf "${1}" -C "${tmp_dir}" && echo "${INFO} Extraction (.tar.gz or .tar.xz format) to temporary directory complete."
     elif [[ "${1}" == *.zip ]]; then
         unzip -o "${1}" -d "${tmp_dir}" && echo "${INFO} Extraction (.zip format) to temporary directory complete."
     fi
@@ -69,11 +69,17 @@ function extract_file_into_charon_dir() {
     # Read contents of the temp directory into an array using mapfile
     mapfile -t contents < <(ls -A "${tmp_dir}")
 
+    echo "${INFO} Moving files from temporary directory to ${CHARON_ROOT_DIR}..."
+
     if [[ ${#contents[@]} == 1 && -d "${tmp_dir}/${contents[0]}" ]]; then
+        echo "${INFO} Found exactly one directory in the archive: ${contents[0]}"
+
         # If there is exactly one directory, move its contents to CHARON_ROOT_DIR
         mv "${tmp_dir}/${contents[0]}"/* "${CHARON_ROOT_DIR}"
         rmdir "${tmp_dir}/${contents[0]}" # Remove the now empty directory
     else
+        echo "${INFO} Moving all files and directories from the temporary directory to ${CHARON_ROOT_DIR}"
+
         # Move all files and directories from the temp directory directly to CHARON_ROOT_DIR
         mv "${tmp_dir}"/* "${CHARON_ROOT_DIR}"
     fi


### PR DESCRIPTION
Fix for wrong file uncompression for `tar.xz` and `tar.xz` formats:

```bash
[ INFO-charon-manager ] Found file to import: /import/charon.tar.gz
[ INFO-charon-manager ] Moving existing files in /opt/charon/.charon to /opt/charon/old-charons/2024-07-19_11-13-37...
[ INFO-charon-manager ] Starting extraction of /import/charon.tar.gz into /opt/charon/.charon
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
[ INFO-charon-manager ] Extraction to temp directory complete.
mv: cannot stat '/tmp/tmp.H4ocZ4ysCZ/*': No such file or directory
[ INFO-charon-manager ] Files moved to /opt/charon/.charon
rmdir: failed to remove '/tmp/tmp.H4ocZ4ysCZ': Directory not empty
```