### PR TITLE
Handle EXTRA OPTS

### DIFF
--- a/cluster/scripts/charon/run-charon.sh
+++ b/cluster/scripts/charon/run-charon.sh
@@ -17,12 +17,6 @@ if [ -n "$DEFINITION_FILE_URL" ]; then
     echo "$DEFINITION_FILE_URL" >$DEFINITION_FILE_URL_FILE
 fi
 
-if [ "$ENABLE_MEV_BOOST" = true ]; then
-    CHARON_EXTRA_OPTS="--builder-api $CHARON_EXTRA_OPTS"
-
-    VALIDATOR_EXTRA_OPTS="--builder=true --builder.selection=builderonly $VALIDATOR_EXTRA_OPTS"
-fi
-
 export CHARON_P2P_EXTERNAL_HOSTNAME=${_DAPPNODE_GLOBAL_DOMAIN}
 
 #############
@@ -116,6 +110,10 @@ function check_DKG() {
 }
 
 function run_charon() {
+    if [ "$ENABLE_MEV_BOOST" = true ]; then
+        CHARON_EXTRA_OPTS="--builder-api $CHARON_EXTRA_OPTS"
+    fi
+
     exec charon run --private-key-file=$ENR_PRIVATE_KEY_FILE --lock-file=$CHARON_LOCK_FILE ${CHARON_EXTRA_OPTS}
 }
 

--- a/cluster/scripts/lodestar/run-validator.sh
+++ b/cluster/scripts/lodestar/run-validator.sh
@@ -15,6 +15,10 @@ function run_lodestar_validator() {
         --suggestedFeeRecipient=${DEFAULT_FEE_RECIPIENT} \
         --distributed"
 
+    if [ "$ENABLE_MEV_BOOST" = true ]; then
+        VALIDATOR_EXTRA_OPTS="--builder=true --builder.selection=builderonly $VALIDATOR_EXTRA_OPTS"
+    fi
+
     if [ -n "$VALIDATOR_EXTRA_OPTS" ]; then
         flags="${flags} ${VALIDATOR_EXTRA_OPTS}"
     fi


### PR DESCRIPTION
Handle `EXTRA_OPTS` properly after migration to `supervisord` process management